### PR TITLE
Remove secrets from tf (tf was overwriting their manually set values)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,15 +16,3 @@ resource "azurerm_resource_group" "rg" {
 
   tags = local.tags
 }
-
-resource "azurerm_key_vault_secret" "definition-importer-username" {
-   name = "definition-importer-username"
-   value = "definition-importer-username-placeholder"
-   key_vault_id = module.finrem-vault.key_vault_id
-}
-
-resource "azurerm_key_vault_secret" "definition-importer-password" {
-   name = "definition-importer-password"
-   value = "definition-importer-password-placeholder"
-   key_vault_id = module.finrem-vault.key_vault_id
-}


### PR DESCRIPTION
Issue caused by the placeholder values set in tf and overwriting correct values that had been manually set

Secrets have been removed from state files in all envs (ithc, perftest, demo, aat, prod) now so can be safely removed from tf without causing them to be deleted
